### PR TITLE
Set the correct build flags for iotivity-node.

### DIFF
--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -34,7 +34,7 @@ INSANE_SKIP_${PN} += "ldflags staticdev"
 
 do_compile_prepend() {
     OCTBDIR="${STAGING_DIR_TARGET}${includedir}/iotivity/resource"
-    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/logger -I${OCTBDIR}/oc_logger -I${OCTBDIR}/ocrandom -DROUTING_GATEWAY"
+    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP -DTCP_ADAPTER"
     export OCTBSTACK_LIBS="-loctbstack"
     export CFLAGS="$CFLAGS -fPIC"
     export CXXFLAGS="$CXXFLAGS -fPIC"

--- a/recipes-web/iotivity-node/iotivity-node.bb
+++ b/recipes-web/iotivity-node/iotivity-node.bb
@@ -15,7 +15,7 @@ INSANE_SKIP_${PN} += "ldflags staticdev"
 
 do_compile_prepend() {
     OCTBDIR="${STAGING_DIR_TARGET}${includedir}/iotivity/resource"
-    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/logger -I${OCTBDIR}/oc_logger -I${OCTBDIR}/ocrandom -DROUTING_GATEWAY"
+    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP -DTCP_ADAPTER"
     export OCTBSTACK_LIBS="-loctbstack"
     export CFLAGS="$CFLAGS -fPIC"
     export CXXFLAGS="$CXXFLAGS -fPIC"


### PR DESCRIPTION
Set the correct build and routing flags that are needed during the compilation of iotivity-node.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
