### PR TITLE
meta-iot-web: Create a package group for Node.js runtime tools

### DIFF
--- a/recipes-core/packagegroups/packagegroup-nodejs-runtime-tools.bb
+++ b/recipes-core/packagegroups/packagegroup-nodejs-runtime-tools.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Runtime tools for Node.js Apps"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    nodejs-npm \
+"


### PR DESCRIPTION
Create a package group for Node.js runtime tools like npm. 

This will be included in ostro-image.bb to pull the package(s) into the -dev images only.

[1] This
[2] https://github.com/nagineni/meta-ostro/commit/d72001 (PR will be created after landing [1])

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
