### PR TITLE
iot-rest-api-server: update to latest version

### DIFF
--- a/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
+++ b/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
@@ -5,21 +5,23 @@ Subject: [PATCH] Remove iotivity-node dependency from package.json
 
 Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
 ---
- package.json | 1 -
- 1 file changed, 1 deletion(-)
+ package.json | 3 ---
+ 1 file changed, 3 deletions(-)
 
 diff --git a/package.json b/package.json
-index 03ec481..8eba909 100644
+index 0679ea9..1c8e1c9 100644
 --- a/package.json
 +++ b/package.json
-@@ -12,7 +12,6 @@
-   "dependencies": {
-     "body-parser": "^1.12.4",
-     "express": "^4.12.3",
--    "iotivity-node": "^1.0.1-1",
-     "minimist": "^1.2.0"
+@@ -9,9 +9,6 @@
    },
+   "author": "Sakari Poussa",
+   "license": "Apache-2.0",
+-  "dependencies": {
+-    "iotivity-node": "^1.0.1-1"
+-  },
    "devDependencies": {
+     "gulp": "^3.8.11",
+     "gulp-nodemon": "^2.0.3"
 -- 
 1.9.1
 

--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git@github.com/01org/iot-rest-api-server.git;protocol=https \
            file://${PN}-ipv4.conf \
            file://${PN}-ipv6.conf \
           "
-SRCREV = "2f1a59bde895062c1d4eb46cd5676df0c55ace3e"
+SRCREV = "c9fa97f8688de2a89cde0c0fa1aadcbbe58c9e08"
 
 S = "${WORKDIR}/git"
 
@@ -90,14 +90,15 @@ do_compile () {
 do_install () {
     install -d ${D}${libdir}/node_modules/iot-rest-api-server/
     install -m 0644 ${S}/index.js ${D}${libdir}/node_modules/iot-rest-api-server/index.js
+    install -m 0644 ${S}/router.js ${D}${libdir}/node_modules/iot-rest-api-server/router.js
+    install -m 0644 ${S}/server.js ${D}${libdir}/node_modules/iot-rest-api-server/server.js
     install -m 0644 ${S}/package.json ${D}${libdir}/node_modules/iot-rest-api-server/package.json
     install -m 0644 ${S}/LICENSE ${D}${libdir}/node_modules/iot-rest-api-server/LICENSE
 
     cp -r ${S}/config/ ${D}${libdir}/node_modules/iot-rest-api-server/
+    cp -r ${S}/handlers/ ${D}${libdir}/node_modules/iot-rest-api-server/
     cp -r ${S}/oic/ ${D}${libdir}/node_modules/iot-rest-api-server/
     cp -r ${S}/routes/ ${D}${libdir}/node_modules/iot-rest-api-server/
-    cp -r ${S}/appfw/ ${D}${libdir}/node_modules/iot-rest-api-server/
-    cp -r ${S}/node_modules/ ${D}${libdir}/node_modules/iot-rest-api-server/
 
     # Install iot-rest-api-server service script
     install -d ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
Pull in the latest version of iot-rest-api-server that contains the new implementation without express. Also, updated install task to skip the unneeded files like app framework bindings and old version of implementation based on express.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
