### PR TITLE
Add soletta-nodejs to the Node.js runtime package group

### DIFF
--- a/recipes-core/packagegroups/packagegroup-nodejs-runtime.bb
+++ b/recipes-core/packagegroups/packagegroup-nodejs-runtime.bb
@@ -7,4 +7,5 @@ RDEPENDS_${PN} = " \
     iotivity-node \
     iot-rest-api-server \
     nodejs \
+    soletta-nodejs \
 "


### PR DESCRIPTION
Pull in the JS bindings to the images by adding soletta-nodejs package to the Node.js runtime package group.

[1] https://github.com/solettaproject/meta-soletta/pull/71
[2] ostroproject/meta-ostro#115 (Enable bindings by default)
[3] This

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
