### PR TITLE
iot-rest-api-server: do not start systemd service by default on boot

### DIFF
--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -21,6 +21,8 @@ S = "${WORKDIR}/git"
 inherit systemd useradd
 
 SYSTEMD_SERVICE_${PN} = "iot-rest-api-server.socket"
+# Do not start the systemd service by default on boot
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r restful"


### PR DESCRIPTION
Disable the systemd service by default. Users can enable it explicitly
with 'systemctl enable iot-rest-api-server.socket'.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
