### PR TITLE
Update iotivity-node and iot-rest-api-server

### DIFF
--- a/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
+++ b/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
@@ -17,7 +17,7 @@ index 0679ea9..1c8e1c9 100644
    "author": "Sakari Poussa",
    "license": "Apache-2.0",
 -  "dependencies": {
--    "iotivity-node": "^1.1.0-3"
+-    "iotivity-node": "^1.1.0-4"
 -  },
    "devDependencies": {
      "gulp": "^3.8.11",

--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git@github.com/01org/iot-rest-api-server.git;protocol=https \
            file://${PN}-ipv4.conf \
            file://${PN}-ipv6.conf \
           "
-SRCREV = "190bf15015f3025575a9a47a6ec2ff14d9437b2c"
+SRCREV = "67d0c07f4f7d2258a63b0d1f6cf7a92e12b5a30c"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-web/iotivity-node/iotivity-node_1.1.0-4.bb
+++ b/recipes-web/iotivity-node/iotivity-node_1.1.0-4.bb
@@ -8,7 +8,7 @@ DEPENDS = "nodejs-native glib-2.0 iotivity"
 RDEPENDS_${PN} += "bash iotivity-resource"
 
 SRC_URI = "git://github.com/otcshare/iotivity-node.git;protocol=https"
-SRCREV = "62e3a344c52c4ea2cd728efaade37892c58fe414"
+SRCREV = "6a8fce657ae9a26da891ed86a66225c66aa9c798"
 
 S = "${WORKDIR}/git"
 INSANE_SKIP_${PN} += "ldflags staticdev"


### PR DESCRIPTION
Pull in the latest iotivity-node and iot-rest-api-server changes:
1. iot-rest-api-server:
   - Set Content-Type to application/json in observe request
   - Update iotivity-node dependency to v1.1.0-4
2. iotivity-node:
   - Implement findPlatforms().
   - Bring presence up-to-spec.
   - Handle malformed create(POST) requests.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
