### PR TITLE
Add recipes for SmartHome Gateway and OCF servers

### DIFF
--- a/recipes-smarthome/smarthome-fan/files/smarthome-fan.service
+++ b/recipes-smarthome/smarthome-fan/files/smarthome-fan.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Fan startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-fan.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-fan/smarthome-fan_git.bb
+++ b/recipes-smarthome/smarthome-fan/smarthome-fan_git.bb
@@ -1,0 +1,35 @@
+SUMMARY = "OCF Fan sensor"
+DESCRIPTION = "OCF Fan sensor server for SmartHome demo"
+HOMEPAGE = "https://github.com/01org/SmartHome-Demo/"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=82d0338d6e61d25fb51cabb1504c0df6"
+
+RDEPENDS_${PN} += "iotivity node-mraa nodejs iotivity-node"
+
+SRC_URI = "git://git@github.com/01org/SmartHome-Demo.git;protocol=https \
+           file://smarthome-fan.service \
+          "
+SRCREV = "a7a6e745fad9485b2b7e8f650dbefa53f22aa11f"
+PV = "0.1+git${SRCPV}"
+
+S = "${WORKDIR}/git/"
+
+INSTALLATION_PATH = "/opt/smarthome-ocf-servers"
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "smarthome-fan.service"
+
+do_install() {
+    install -d ${D}${INSTALLATION_PATH}
+    install -m 0664 ${S}/ocf-servers/js-servers/fan.js ${D}${INSTALLATION_PATH}/smarthome-fan.js
+
+    # Install SmartHome fan service script
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/smarthome-fan.service ${D}/${systemd_unitdir}/system/
+}
+
+FILES_${PN} = "${INSTALLATION_PATH} \
+               ${systemd_unitdir}/system/ \
+              "
+
+PACKAGES = "${PN}"

--- a/recipes-smarthome/smarthome-gateway/files/0001-Remove-iotivity-node-dependency.patch
+++ b/recipes-smarthome/smarthome-gateway/files/0001-Remove-iotivity-node-dependency.patch
@@ -1,0 +1,25 @@
+From 249c69b10e717b4bfab930d1a9c0dc5d891bf1d4 Mon Sep 17 00:00:00 2001
+From: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
+Date: Mon, 27 Jun 2016 12:58:05 +0300
+Subject: [PATCH] Remove iotivity-node dependency from package.json
+
+Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
+---
+ package.json | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 78f4e27..60982bc 100644
+--- a/package.json
++++ b/package.json
+@@ -9,7 +9,6 @@
+   "author": "",
+   "license": "Apache-2.0",
+   "dependencies": { 
+-	"iotivity-node": "^1.1.0-4",
+ 	"express": "*",
+ 	"websocket": "*",
+ 	"http": "*"
+-- 
+1.9.1
+

--- a/recipes-smarthome/smarthome-gateway/files/smarthome-gateway-ipv4.conf
+++ b/recipes-smarthome/smarthome-gateway/files/smarthome-gateway-ipv4.conf
@@ -1,0 +1,6 @@
+[Unit]
+After=iptables.service
+
+[Socket]
+ExecStartPre=/usr/sbin/iptables -w -A INPUT -p tcp --dport 8080 -j ACCEPT
+ExecStopPost=/usr/sbin/iptables -w -D INPUT -p tcp --dport 8080 -j ACCEPT

--- a/recipes-smarthome/smarthome-gateway/files/smarthome-gateway-ipv6.conf
+++ b/recipes-smarthome/smarthome-gateway/files/smarthome-gateway-ipv6.conf
@@ -1,0 +1,6 @@
+[Unit]
+After=ip6tables.service
+
+[Socket]
+ExecStartPre=/usr/sbin/ip6tables -w -A INPUT -p tcp --dport 8080 -j ACCEPT
+ExecStopPost=/usr/sbin/ip6tables -w -D INPUT -p tcp --dport 8080 -j ACCEPT

--- a/recipes-smarthome/smarthome-gateway/files/smarthome-gateway.service
+++ b/recipes-smarthome/smarthome-gateway/files/smarthome-gateway.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=SmartHome Gateway startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /usr/lib/node_modules/smarthome-gateway/first_server.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-gateway/files/smarthome-gateway.socket
+++ b/recipes-smarthome/smarthome-gateway/files/smarthome-gateway.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=SmartHome Gateway socket
+
+[Socket]
+ListenStream=8080
+Accept=false
+
+[Install]
+WantedBy=sockets.target

--- a/recipes-smarthome/smarthome-gateway/files/smarthome-power.service
+++ b/recipes-smarthome/smarthome-gateway/files/smarthome-power.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Power startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-power.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-gateway/smarthome-gateway.bb
+++ b/recipes-smarthome/smarthome-gateway/smarthome-gateway.bb
@@ -1,0 +1,122 @@
+SUMMARY = "SmartHome Gateway"
+DESCRIPTION = "SmartHome webserver running on the home gateway"
+HOMEPAGE = "https://github.com/01org/SmartHome-Demo/"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=82d0338d6e61d25fb51cabb1504c0df6"
+
+DEPENDS = "nodejs-native iotivity iotivity-node"
+RDEPENDS_${PN} += "iotivity node-mraa nodejs iotivity-node iptables"
+
+SRC_URI = "git://git@github.com/01org/SmartHome-Demo.git;protocol=https \
+           file://0001-Remove-iotivity-node-dependency.patch \
+           file://smarthome-gateway.service \
+           file://smarthome-gateway.socket \
+           file://${PN}-ipv4.conf \
+           file://${PN}-ipv6.conf \
+           file://smarthome-power.service \
+          "
+
+SRCREV = "a7a6e745fad9485b2b7e8f650dbefa53f22aa11f"
+PV = "0.1+git${SRCPV}"
+
+S = "${WORKDIR}/git/"
+
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "smarthome-gateway.socket \
+                         smarthome-power.service \
+                        "
+INSANE_SKIP_${PN} += "ldflags staticdev"
+
+POWER_INSTALLATION_PATH = "/opt/smarthome-ocf-servers"
+
+do_compile () {
+    # changing the home directory to the working directory, the .npmrc will be created in this directory
+    export HOME=${WORKDIR}
+
+    # does not build dev packages
+    npm config set dev false
+
+    # access npm registry using http
+    npm set strict-ssl false
+    npm config set registry http://registry.npmjs.org/
+
+    # configure http proxy if neccessary
+    if [ -n "${http_proxy}" ]; then
+        npm config set proxy ${http_proxy}
+    fi
+    if [ -n "${HTTP_PROXY}" ]; then
+        npm config set proxy ${HTTP_PROXY}
+    fi
+
+    # configure cache to be in working directory
+    npm set cache ${WORKDIR}/npm_cache
+
+    # clear local cache prior to each compile
+    npm cache clear
+
+    case ${TARGET_ARCH} in
+        i?86) targetArch="ia32"
+            echo "targetArch = 32"
+            ;;
+        x86_64) targetArch="x64"
+            echo "targetArch = 64"
+            ;;
+        arm) targetArch="arm"
+            ;;
+        mips) targetArch="mips"
+            ;;
+        sparc) targetArch="sparc"
+            ;;
+        *) echo "unknown architecture"
+           exit 1
+            ;;
+    esac
+
+    # Compile and install node modules in source directory
+    npm --arch=${targetArch} --production --verbose install
+}
+
+do_install () {
+    install -d ${D}${libdir}/node_modules/smarthome-gateway/
+
+    install -m 0644 ${S}/first_server.js ${D}${libdir}/node_modules/smarthome-gateway/first_server.js
+    install -m 0644 ${S}/data.json ${D}${libdir}/node_modules/smarthome-gateway/data.json
+    install -m 0644 ${S}/package.json ${D}${libdir}/node_modules/smarthome-gateway/package.json
+
+    cp -r ${S}/gateway-webui/ ${D}${libdir}/node_modules/smarthome-gateway/
+    cp -r ${S}/node_modules/ ${D}${libdir}/node_modules/smarthome-gateway/
+
+    # Install SmartHome Power sensor
+    install -d ${D}${POWER_INSTALLATION_PATH}
+    install -m 0664 ${S}/ocf-servers/js-servers/power-uart.js ${D}${POWER_INSTALLATION_PATH}/smarthome-power.js
+
+    # Install SmartHome Power service script
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/smarthome-power.service ${D}/${systemd_unitdir}/system/
+
+    # Install SmartHome gateway service script
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/smarthome-gateway.service ${D}/${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/smarthome-gateway.socket ${D}/${systemd_unitdir}/system/
+
+    # Copy the firewall configuration fragments in place
+    install -d ${D}${systemd_unitdir}/system/${PN}.socket.d
+    install -m 0644 ${WORKDIR}/${PN}-ipv4.conf ${D}${systemd_unitdir}/system/${PN}.socket.d
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/${PN}-ipv6.conf ${D}${systemd_unitdir}/system/${PN}.socket.d
+    fi
+
+}
+
+FILES_${PN} = "${libdir}/node_modules/smarthome-gateway/ \
+               ${POWER_INSTALLATION_PATH} \
+               ${systemd_unitdir}/system/ \
+               ${systemd_unitdir}/system/${PN}.socket.d/${PN}-ipv4.conf \
+               ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', \
+                   '${systemd_unitdir}/system/${PN}.socket.d/${PN}-ipv6.conf', '', d)} \
+              "
+
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+PACKAGES = "${PN}"

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-button-toggle.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-button-toggle.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome toggle button startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-button-toggle.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-buzzer.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-buzzer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Buzzer startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-buzzer.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-gas.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-gas.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Gas sensor startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-gas.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-illuminance.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-illuminance.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome illuminance startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-illuminance.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-led.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-led.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome LED startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-led.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-motion.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-motion.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Motion sensor startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-motion.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-rgbled.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-rgbled.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome RGB LED sensor startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-rgbled.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/files/smarthome-temperature.service
+++ b/recipes-smarthome/smarthome-ocf-servers/files/smarthome-temperature.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Temperature sensor startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-temperature.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-ocf-servers/smarthome-ocf-servers_git.bb
+++ b/recipes-smarthome/smarthome-ocf-servers/smarthome-ocf-servers_git.bb
@@ -1,0 +1,58 @@
+SUMMARY = "OCF servers"
+DESCRIPTION = "Motion, Gas, Buzzer, LED, Illuminance, RGB LED and Temperature OCF servers for SmartHome demo"
+HOMEPAGE = "https://github.com/01org/SmartHome-Demo/"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=82d0338d6e61d25fb51cabb1504c0df6"
+
+RDEPENDS_${PN} += "iotivity node-mraa nodejs node-upm iotivity-node"
+
+SRC_URI = "git://git@github.com/01org/SmartHome-Demo.git;protocol=https \
+           file://smarthome-motion.service \
+           file://smarthome-gas.service \
+           file://smarthome-led.service \
+           file://smarthome-rgbled.service \
+           file://smarthome-button-toggle.service \
+           file://smarthome-illuminance.service \
+           file://smarthome-buzzer.service \
+           file://smarthome-temperature.service \
+          "
+
+SRCREV = "a7a6e745fad9485b2b7e8f650dbefa53f22aa11f"
+PV = "0.1+git${SRCPV}"
+
+S = "${WORKDIR}/git/"
+
+INSTALLATION_PATH = "/opt/smarthome-ocf-servers"
+
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "smarthome-motion.service \
+                         smarthome-gas.service \
+                         smarthome-led.service \
+                         smarthome-rgbled.service \
+                         smarthome-button-toggle.service \
+                         smarthome-illuminance.service \
+                         smarthome-buzzer.service \
+                         smarthome-temperature.service \
+                        "
+do_install() {
+    install -d ${D}${INSTALLATION_PATH}
+    install -m 0664 ${S}/ocf-servers/js-servers/ambient_light.js ${D}${INSTALLATION_PATH}/smarthome-illuminance.js
+    install -m 0664 ${S}/ocf-servers/js-servers/motion.js ${D}${INSTALLATION_PATH}/smarthome-motion.js
+    install -m 0664 ${S}/ocf-servers/js-servers/gas.js ${D}${INSTALLATION_PATH}/smarthome-gas.js
+    install -m 0664 ${S}/ocf-servers/js-servers/led.js ${D}${INSTALLATION_PATH}/smarthome-led.js
+    install -m 0664 ${S}/ocf-servers/js-servers/temperature.js ${D}${INSTALLATION_PATH}/smarthome-temperature.js
+    install -m 0664 ${S}/ocf-servers/js-servers/rgb_led.js ${D}${INSTALLATION_PATH}/smarthome-rgbled.js
+    install -m 0664 ${S}/ocf-servers/js-servers/button-toggle.js ${D}${INSTALLATION_PATH}/smarthome-button-toggle.js
+    install -m 0664 ${S}/ocf-servers/js-servers/buzzer.js ${D}${INSTALLATION_PATH}/smarthome-buzzer.js
+
+    # Install SmartHome sensors service scripts
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/*.service ${D}/${systemd_unitdir}/system/
+}
+
+FILES_${PN} = "${INSTALLATION_PATH} \
+               ${systemd_unitdir}/system/ \
+              "
+
+PACKAGES = "${PN}"

--- a/recipes-smarthome/smarthome-solar/files/smarthome-solar.service
+++ b/recipes-smarthome/smarthome-solar/files/smarthome-solar.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SmartHome Solar Panel startup service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/smarthome-ocf-servers/smarthome-solar.js
+Environment='NODE_PATH=/usr/lib/node_modules/'
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-smarthome/smarthome-solar/smarthome-solar_git.bb
+++ b/recipes-smarthome/smarthome-solar/smarthome-solar_git.bb
@@ -1,0 +1,36 @@
+SUMMARY = "OCF Solar Panel sensor"
+DESCRIPTION = "OCF Solar Panel sensor server for SmartHome demo"
+HOMEPAGE = "https://github.com/01org/SmartHome-Demo/"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=82d0338d6e61d25fb51cabb1504c0df6"
+
+RDEPENDS_${PN} += "iotivity node-mraa nodejs node-upm iotivity-node"
+
+SRC_URI = "git://git@github.com/01org/SmartHome-Demo.git;protocol=https \
+           file://smarthome-solar.service \
+          "
+SRCREV = "a7a6e745fad9485b2b7e8f650dbefa53f22aa11f"
+PV = "0.1+git${SRCPV}"
+
+S = "${WORKDIR}/git/"
+
+INSTALLATION_PATH = "/opt/smarthome-ocf-servers"
+
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "smarthome-solar.service"
+
+do_install() {
+    install -d ${D}${INSTALLATION_PATH}
+    install -m 0664 ${S}/ocf-servers/js-servers/solar.js ${D}${INSTALLATION_PATH}/smarthome-solar.js
+
+    # Install SmartHome Solar service script
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/smarthome-solar.service ${D}/${systemd_unitdir}/system/
+}
+
+FILES_${PN} = "${INSTALLATION_PATH} \
+               ${systemd_unitdir}/system/ \
+              "
+
+PACKAGES = "${PN}"


### PR DESCRIPTION
Add recipes for SmartHome gateway and OCF servers, so that they can be built as bundles and install on the devices(s) using `swupd` tool or REST API server.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
