### PR TITLE
nodejs: Upgrade to 4.5.0

### DIFF
--- a/recipes-devtools/nodejs/files/0002-generate-pkg-config-file-for-node-and-install.patch
+++ b/recipes-devtools/nodejs/files/0002-generate-pkg-config-file-for-node-and-install.patch
@@ -1,6 +1,6 @@
-From 178d0624120748a8625bb1169a9c65d2dfbc76aa Mon Sep 17 00:00:00 2001
+From 56d77d9bc7fc99d30b3e682bb82e8c6cac9c86f8 Mon Sep 17 00:00:00 2001
 From: Krisztian Litkey <krisztian.litkey@intel.com>
-Date: Fri, 8 Jan 2016 12:43:09 +0200
+Date: Wed, 17 Aug 2016 15:29:30 +0300
 Subject: [PATCH] nodejs: generate pkg-config file for node and install it
  during make install.
 
@@ -12,10 +12,10 @@ Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
  2 files changed, 109 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 02619fa..8363801 100644
+index fae0958..372c48b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -59,7 +59,7 @@ config.gypi: configure
+@@ -76,7 +76,7 @@ config.gypi: configure
  		$(error No $@, please run ./configure first)
  	fi
  
@@ -24,7 +24,7 @@ index 02619fa..8363801 100644
  	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
  
  uninstall:
-@@ -462,6 +462,17 @@ ifneq ($(haswrk), 0)
+@@ -595,6 +595,17 @@ ifneq ($(haswrk), 0)
  	@exit 1
  endif
  
@@ -43,10 +43,10 @@ index 02619fa..8363801 100644
  	@$(NODE) benchmark/common.js net
  
 diff --git a/configure b/configure
-index 0e83d8a..b9671c0 100755
+index 0be3a52..140bd4f 100755
 --- a/configure
 +++ b/configure
-@@ -75,6 +75,11 @@ parser.add_option('--gdb',
+@@ -77,6 +77,11 @@ parser.add_option('--gdb',
      dest='gdb',
      help='add gdb support')
  
@@ -58,7 +58,7 @@ index 0e83d8a..b9671c0 100755
  parser.add_option('--no-ifaddrs',
      action='store_true',
      dest='no_ifaddrs',
-@@ -1125,9 +1130,16 @@ config = {
+@@ -1176,9 +1181,16 @@ config = {
    'PYTHON': sys.executable,
  }
  
@@ -75,7 +75,7 @@ index 0e83d8a..b9671c0 100755
  config = '\n'.join(map('='.join, config.iteritems())) + '\n'
  
  write('config.mk',
-@@ -1147,4 +1159,89 @@ gyp_args += args
+@@ -1198,4 +1210,89 @@ gyp_args += args
  if warn.warned:
    warn('warnings were emitted in the configure phase')
  

--- a/recipes-devtools/nodejs/nodejs_4.5.0.bb
+++ b/recipes-devtools/nodejs/nodejs_4.5.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
 HOMEPAGE = "http://nodejs.org"
-LICENSE = "MIT & BSD-2-Clause & BSD-3-Clause & ISC & AFL-2.0 & Apache-2.0 & OpenSSL & Zlib & Artistic-2.0 & (BSD-3-Clause | GPLv2)"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=b70c304f43f326ddbc3474ba2b685522"
+LICENSE = "MIT & BSD-2-Clause & BSD-3-Clause & ISC & CC-BY-3.0 & AFL-2.1 & Apache-2.0 & OpenSSL & Zlib & Artistic-2.0 & (BSD-3-Clause | GPLv2)"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8e3c01094f0fcb889b13f0354e52f914"
 
 DEPENDS = "openssl"
 DEPENDS_append_class-target = " nodejs-native"
@@ -10,17 +10,17 @@ COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
 COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
 COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
 
-SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=node \
-           http://nodejs.org/download/release/v${PV}/node-v${PV}-headers.tar.gz;name=node-headers;unpack=false \
+SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz;name=node \
+           http://nodejs.org/dist/v${PV}/node-v${PV}-headers.tar.gz;name=node-headers;unpack=false \
            file://0002-generate-pkg-config-file-for-node-and-install.patch \
 "
 SRC_URI_append_quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"
 SRC_URI_append_intel-quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"
 
-SRC_URI[node.md5sum] = "ef756c3e773f08bccada08eb37ee699c"
-SRC_URI[node.sha256sum] = "f3e604cc4d05a4810c37cd43a838a2dc4399d517bd1e8c53b7670dcffc4dc481"
-SRC_URI[node-headers.md5sum] = "b021c28a69e29d152509c1606e1587b6"
-SRC_URI[node-headers.sha256sum] = "e759ee28a27dc47a5c80e48b063c0bee015f3b6d2f8f593ad0eabfab0ebb3922"
+SRC_URI[node.md5sum] = "ac8e38c83f29e83d496d4bc4283487b0"
+SRC_URI[node.sha256sum] = "97b99d378c56802444208409568e2e66c46332897f06aead74d1ffbe733bd488"
+SRC_URI[node-headers.md5sum] = "6c93a4cb93e1ddc793061f148ee2b4e6"
+SRC_URI[node-headers.sha256sum] = "12ee966eef2abc928f6d7fcf9cfcf2913ef0e59ae07e2dcc20726246ab174fd8"
 
 S = "${WORKDIR}/node-v${PV}"
 


### PR DESCRIPTION
Upgrade nodejs v4.4.1 to the latest stable version 4.5.0.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
