### PR TITLE
Update iotivity-node and iot-rest-api-server to latest version

### DIFF
--- a/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
+++ b/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
@@ -17,7 +17,7 @@ index 0679ea9..1c8e1c9 100644
    "author": "Sakari Poussa",
    "license": "Apache-2.0",
 -  "dependencies": {
--    "iotivity-node": "^1.1.0-4"
+-    "iotivity-node": "^1.1.1-3"
 -  },
    "devDependencies": {
      "gulp": "^3.8.11",

--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git@github.com/01org/iot-rest-api-server.git;protocol=https \
            file://${PN}-ipv4.conf \
            file://${PN}-ipv6.conf \
           "
-SRCREV = "67d0c07f4f7d2258a63b0d1f6cf7a92e12b5a30c"
+SRCREV = "a1ea26d1116a2326b55c05e9bad42ebc1ec68457"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-web/iotivity-node/iotivity-node_1.1.1-3.bb
+++ b/recipes-web/iotivity-node/iotivity-node_1.1.1-3.bb
@@ -8,7 +8,7 @@ DEPENDS = "nodejs-native glib-2.0 iotivity"
 RDEPENDS_${PN} += "bash iotivity-resource"
 
 SRC_URI = "git://github.com/otcshare/iotivity-node.git;protocol=https"
-SRCREV = "6a8fce657ae9a26da891ed86a66225c66aa9c798"
+SRCREV = "6cb68eeaaf8e814571ceb27c8359aec32e58575e"
 
 S = "${WORKDIR}/git"
 INSANE_SKIP_${PN} += "ldflags staticdev"


### PR DESCRIPTION
Update for iotivity v1.1.1 is already in Ostro os pending queue, so this will update the iotivity-node to the v1.1.1.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
