### PR TITLE
recipes-web: Set the correct CFLAGS for iotivity-node.

### DIFF
--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -36,7 +36,7 @@ INSANE_SKIP_${PN} += "ldflags staticdev"
 
 do_compile_prepend() {
     OCTBDIR="${STAGING_DIR_TARGET}${includedir}/iotivity/resource"
-    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP -DTCP_ADAPTER"
+    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP"
     export OCTBSTACK_LIBS="-loctbstack"
     export CFLAGS="$CFLAGS -fPIC"
     export CXXFLAGS="$CXXFLAGS -fPIC"

--- a/recipes-web/iotivity-node/iotivity-node_1.1.1-3.bb
+++ b/recipes-web/iotivity-node/iotivity-node_1.1.1-3.bb
@@ -15,7 +15,7 @@ INSANE_SKIP_${PN} += "ldflags staticdev"
 
 do_compile_prepend() {
     OCTBDIR="${STAGING_DIR_TARGET}${includedir}/iotivity/resource"
-    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP -DTCP_ADAPTER"
+    export OCTBSTACK_CFLAGS="-I${OCTBDIR} -I${OCTBDIR}/stack -I${OCTBDIR}/ocrandom -DROUTING_EP"
     export OCTBSTACK_LIBS="-loctbstack"
     export CFLAGS="$CFLAGS -fPIC"
     export CXXFLAGS="$CXXFLAGS -fPIC"


### PR DESCRIPTION
This sets the correct CFLAGS that are needed during the compilation of iotivity-node. TCP_ADAPTER is not set by default in iotivity, so removing it from the CFLAGS in iotivity-node

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
