### PR TITLE
packagegroup-nodejs-runtime.bb: remove soletta Node.js bindings

### DIFF
--- a/recipes-core/packagegroups/packagegroup-nodejs-runtime.bb
+++ b/recipes-core/packagegroups/packagegroup-nodejs-runtime.bb
@@ -7,5 +7,4 @@ RDEPENDS_${PN} = " \
     iotivity-node \
     iot-rest-api-server \
     nodejs \
-    soletta-nodejs \
 "


### PR DESCRIPTION
Soletta Node.js bindings are not used at the moment, so removing the package
from the dependency list.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>