### PR TITLE
iot-rest-api-server: Only report warning if user unknown

### DIFF
--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -24,6 +24,7 @@ SYSTEMD_SERVICE_${PN} = "iot-rest-api-server.socket"
 # Do not start the systemd service by default on boot
 SYSTEMD_AUTO_ENABLE_${PN} = "disable"
 
+USERADD_ERROR_DYNAMIC = "0"
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r restful"
 USERADD_PARAM_${PN} = "\


### PR DESCRIPTION
This prevent layer's users to overload recipe
if not using static users/group table (USERADD_UID_TABLES).

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>