### PR TITLE
Support aarch64 targets by passing arm64 to npm

### DIFF
--- a/recipes-smarthome/smarthome-gateway/smarthome-gateway.bb
+++ b/recipes-smarthome/smarthome-gateway/smarthome-gateway.bb
@@ -61,6 +61,8 @@ do_compile () {
             ;;
         arm) targetArch="arm"
             ;;
+        aarch64) targetArch="arm64"
+            ;;
         mips) targetArch="mips"
             ;;
         sparc) targetArch="sparc"

--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -75,6 +75,8 @@ do_compile () {
             ;;
         arm) targetArch="arm"
             ;;
+        aarch64) targetArch="arm64"
+            ;;
         mips) targetArch="mips"
             ;;
         sparc) targetArch="sparc"

--- a/recipes-web/iotivity-node/iotivity-node_1.2.0-2.bb
+++ b/recipes-web/iotivity-node/iotivity-node_1.2.0-2.bb
@@ -55,6 +55,8 @@ do_compile () {
             ;;
         arm) targetArch="arm"
             ;;
+        aarch64) targetArch="arm64"
+            ;;
         mips) targetArch="mips"
             ;;
         sparc) targetArch="sparc"


### PR DESCRIPTION
In bb files for iotivity-node, smarthome-gateway and
iot-rest-api-server, do_compile() includes a case statement to translate
compiler architecture designations to the strings used by the npm
command for the same purpose (--arch flag). The target architecture for
Dragonboard (and several other 64 bit ARM boards) is aarch64.  aarch64
was not included in the known list, resulting in the printout "unknown
architecture" and stopped operation.

Add "aarch64" and translate it to what npm expects, which is "arm64".

All 3 .bb files changed identically.  Some refactoring might be advised
since the affected code is repetitive.

[GDP-571] Iotivity build failure on Dragonboard

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>