### PR TITLE
nodejs: add nodejs-gyp package

### DIFF
--- a/recipes-devtools/nodejs/nodejs_4.5.0.bb
+++ b/recipes-devtools/nodejs/nodejs_4.5.0.bb
@@ -100,7 +100,11 @@ pkg_prerm_${PN} () {
 
 PACKAGES =+ "${PN}-npm"
 FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm"
-RDEPENDS_${PN}-npm = "bash python-shell python-datetime python-subprocess python-textutils \
+
+PACKAGES =+ "${PN}-gyp"
+FILES_${PN}-gyp = "${exec_prefix}/lib/node_modules/npm/bin/node-gyp-bin \
+                   ${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp"
+RDEPENDS_${PN}-gyp = "bash python-shell python-datetime python-subprocess python-textutils \
                       python-netclient python-ctypes python-misc python-compiler python-multiprocessing"
 
 PACKAGES =+ "${PN}-systemtap"


### PR DESCRIPTION
node-gyp is needed only for on-target development and can be dropped
together with run-time dependencies on python if such functionality
is not needed.

Add new nodejs-gyp package and move node-js from the nodejs-npm
package.