### PR TITLE
Update nodejs and other web components to the latest

### DIFF
--- a/recipes-devtools/nodejs/nodejs_6.11.0.bb
+++ b/recipes-devtools/nodejs/nodejs_6.11.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
 HOMEPAGE = "http://nodejs.org"
 LICENSE = "MIT & BSD-2-Clause & BSD-3-Clause & ISC & CC-BY-3.0 & AFL-2.1 & Apache-2.0 & OpenSSL & Zlib & Artistic-2.0 & (BSD-3-Clause | GPLv2)"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=8e3c01094f0fcb889b13f0354e52f914"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=41a3a0ccf7f515cac3377389dd8faac8"
 
 DEPENDS = "openssl"
 DEPENDS_append_class-target = " nodejs-native"
@@ -16,10 +16,10 @@ SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz;name=node \
 SRC_URI_append_quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"
 SRC_URI_append_intel-quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"
 
-SRC_URI[node.md5sum] = "ac8e38c83f29e83d496d4bc4283487b0"
-SRC_URI[node.sha256sum] = "97b99d378c56802444208409568e2e66c46332897f06aead74d1ffbe733bd488"
-SRC_URI[node-headers.md5sum] = "6c93a4cb93e1ddc793061f148ee2b4e6"
-SRC_URI[node-headers.sha256sum] = "12ee966eef2abc928f6d7fcf9cfcf2913ef0e59ae07e2dcc20726246ab174fd8"
+SRC_URI[node.md5sum] = "301c9afa4848561173d1dbe017d03636"
+SRC_URI[node.sha256sum] = "02ba35391edea2b294c736489af01954ce6e6c39d318f4423ae6617c69ef0a51"
+SRC_URI[node-headers.md5sum] = "d68f6bf03812ddab676d7e2313c29413"
+SRC_URI[node-headers.sha256sum] = "a82caf153b7649656bce64dec40d136008babbef419e35b2a83242049de44b23"
 
 S = "${WORKDIR}/node-v${PV}"
 
@@ -46,8 +46,9 @@ do_configure () {
     GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
     # $TARGET_ARCH settings don't match --dest-cpu settings
    ./configure --prefix=${prefix} --without-snapshot --shared-openssl \
-               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH', True), d)}" \
+               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
                --dest-os=linux \
+               --without-intl \
                ${ARCHFLAGS}
 }
 

--- a/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
+++ b/recipes-web/iot-rest-api-server/files/0001-Remove-iotivity-node-dependency.patch
@@ -1,6 +1,6 @@
-From 2006a5696880e4389016ab68952af3021a44b463 Mon Sep 17 00:00:00 2001
+From 33a971fc5b9deeaf0e55070a585785b1c5f3d4c8 Mon Sep 17 00:00:00 2001
 From: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
-Date: Fri, 27 Jan 2017 15:50:38 +0200
+Date: Wed, 7 Jun 2017 10:30:38 +0300
 Subject: [PATCH] Remove iotivity-node dependency from package.json
 
 Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
@@ -9,7 +9,7 @@ Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
  1 file changed, 3 deletions(-)
 
 diff --git a/package.json b/package.json
-index 001d0f9..75f9239 100644
+index d141568..f12035e 100644
 --- a/package.json
 +++ b/package.json
 @@ -9,9 +9,6 @@
@@ -17,11 +17,11 @@ index 001d0f9..75f9239 100644
    "author": "Sakari Poussa",
    "license": "Apache-2.0",
 -  "dependencies": {
--    "iotivity-node": "^1.2.0-2"
+-    "iotivity-node": "^1.2.0-5"
 -  },
    "devDependencies": {
      "gulp": "^3.8.11",
      "gulp-nodemon": "^2.0.3"
 -- 
-1.9.1
+2.7.4
 

--- a/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git@github.com/01org/iot-rest-api-server.git;protocol=https \
            file://${PN}-ipv4.conf \
            file://${PN}-ipv6.conf \
           "
-SRCREV = "3979442c554d4aa0a73dd642f8448aeb78ee86ec"
+SRCREV = "8d1795d124c51b54d4b6ba49cb49f0a4d96602fe"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-web/iotivity-node/iotivity-node_1.2.0-5.bb
+++ b/recipes-web/iotivity-node/iotivity-node_1.2.0-5.bb
@@ -8,7 +8,7 @@ DEPENDS = "nodejs-native glib-2.0 iotivity"
 RDEPENDS_${PN} += "bash iotivity-resource"
 
 SRC_URI = "git://github.com/otcshare/iotivity-node.git;protocol=https"
-SRCREV = "13cdbaa48c8ef938976e02b32fbfd51206110179"
+SRCREV = "3e9d0e573f07d77b1b42c8d95d9bec9b6615840d"
 
 S = "${WORKDIR}/git"
 INSANE_SKIP_${PN} += "ldflags staticdev"


### PR DESCRIPTION
Update Node.js, iotivity-node and iot-rest-api-server to the latest.

Node.js:  from v4.5.0 to the latest stable version v6.11.0.
Iotivity-node: from 1.2.0-2 to 1.2.0-5
iot-rest-api-server: github master.
