### PR TITLE
nodejs: Fix Node.js build errors with gcc7

### DIFF
--- a/recipes-devtools/nodejs/files/0002_fix_v8_build_errors_with_gcc7.patch
+++ b/recipes-devtools/nodejs/files/0002_fix_v8_build_errors_with_gcc7.patch
@@ -1,0 +1,98 @@
+From 11c7e0164af7f6b33df13a658fc1c0effb502662 Mon Sep 17 00:00:00 2001
+From: Zuzana Svetlikova <zsvetlik@redhat.com>
+Date: Fri, 9 Jun 2017 14:07:19 +0200
+Subject: [PATCH] v8: fix build errors with g++ 7
+
+This is a local patch because upstream fixed it differently by moving
+large chunks of code out of objects.h.  We cannot easily back-port
+those changes due to their size and invasiveness.
+
+Fixes: https://github.com/nodejs/node/issues/10388
+PR-URL: https://github.com/nodejs/node/pull/12392
+Backport-PR-URL: https://github.com/nodejs/node/pull/13574
+Reviewed-By: Anna Henningsen <anna@addaleax.net>
+Reviewed-By: Benjamin Gruenbaum <benjamingr@gmail.com>
+Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>
+Reviewed-By: James M Snell <jasnell@gmail.com>
+---
+ deps/v8/src/objects-body-descriptors.h |  2 +-
+ deps/v8/src/objects-inl.h              | 21 +++++++++++++++++++++
+ deps/v8/src/objects.h                  | 20 ++++----------------
+ 3 files changed, 26 insertions(+), 17 deletions(-)
+
+diff --git a/deps/v8/src/objects-body-descriptors.h b/deps/v8/src/objects-body-descriptors.h
+index 91cb8883be8..a1c3634bd76 100644
+--- a/deps/v8/src/objects-body-descriptors.h
++++ b/deps/v8/src/objects-body-descriptors.h
+@@ -99,7 +99,7 @@ class FixedBodyDescriptor final : public BodyDescriptorBase {
+ 
+   template <typename StaticVisitor>
+   static inline void IterateBody(HeapObject* obj, int object_size) {
+-    IterateBody(obj);
++    IterateBody<StaticVisitor>(obj);
+   }
+ };
+ 
+diff --git a/deps/v8/src/objects-inl.h b/deps/v8/src/objects-inl.h
+index 11f4d7498d7..72208c2f00f 100644
+--- a/deps/v8/src/objects-inl.h
++++ b/deps/v8/src/objects-inl.h
+@@ -36,6 +36,27 @@
+ namespace v8 {
+ namespace internal {
+ 
++template <typename Derived, typename Shape, typename Key>
++uint32_t HashTable<Derived, Shape, Key>::Hash(Key key) {
++  if (Shape::UsesSeed) {
++    return Shape::SeededHash(key, GetHeap()->HashSeed());
++  } else {
++    return Shape::Hash(key);
++  }
++}
++
++
++template <typename Derived, typename Shape, typename Key>
++uint32_t HashTable<Derived, Shape, Key>::HashForObject(Key key,
++                                                       Object* object) {
++  if (Shape::UsesSeed) {
++    return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
++  } else {
++    return Shape::HashForObject(key, object);
++  }
++}
++
++
+ PropertyDetails::PropertyDetails(Smi* smi) {
+   value_ = smi->value();
+ }
+diff --git a/deps/v8/src/objects.h b/deps/v8/src/objects.h
+index d1632c9deb2..47b02dadcff 100644
+--- a/deps/v8/src/objects.h
++++ b/deps/v8/src/objects.h
+@@ -3261,22 +3261,10 @@ class HashTableBase : public FixedArray {
+ template <typename Derived, typename Shape, typename Key>
+ class HashTable : public HashTableBase {
+  public:
+-  // Wrapper methods
+-  inline uint32_t Hash(Key key) {
+-    if (Shape::UsesSeed) {
+-      return Shape::SeededHash(key, GetHeap()->HashSeed());
+-    } else {
+-      return Shape::Hash(key);
+-    }
+-  }
+-
+-  inline uint32_t HashForObject(Key key, Object* object) {
+-    if (Shape::UsesSeed) {
+-      return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
+-    } else {
+-      return Shape::HashForObject(key, object);
+-    }
+-  }
++  // Wrapper methods.  Defined in src/objects-inl.h
++  // to break a cycle with src/heap/heap.h.
++  inline uint32_t Hash(Key key);
++  inline uint32_t HashForObject(Key key, Object* object);
+ 
+   // Returns a new HashTable object.
+   MUST_USE_RESULT static Handle<Derived> New(

--- a/recipes-devtools/nodejs/nodejs_6.11.0.bb
+++ b/recipes-devtools/nodejs/nodejs_6.11.0.bb
@@ -13,6 +13,7 @@ COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
 
 SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz;name=node \
            http://nodejs.org/dist/v${PV}/node-v${PV}-headers.tar.gz;name=node-headers;unpack=false \
+           file://0002_fix_v8_build_errors_with_gcc7.patch \
 "
 SRC_URI_append_quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"
 SRC_URI_append_intel-quark = "file://0001-nodejs-add-compile-flag-options-for-quark.patch"


### PR DESCRIPTION
Fix build errors with GCC7 by backporting a patch
from Node.js upstream.

Fixes #44

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>