### PR TITLE
conf: Align layer name to directory name

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,6 +2,6 @@ BBPATH .= ":${LAYERDIR}"
 
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "iotweb"
-BBFILE_PATTERN_iotweb := "^${LAYERDIR}/"
-BBFILE_PRIORITY_iotweb = "9"
+BBFILE_COLLECTIONS += "iot-web"
+BBFILE_PATTERN_iot-web := "^${LAYERDIR}/"
+BBFILE_PRIORITY_iot-web = "9"


### PR DESCRIPTION
Rename layer name to "iot-web from "iotweb", to be used in collections.

This way this layer can be optionally and dynamicaly overloaded by sub layer,
using this scriplet:

  BBFILES += "${@' '.join('${LAYERDIR}/meta-%s/recipes*/*/*.bb' % layer \
  for layer in BBFILE_COLLECTIONS.split())}"

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>